### PR TITLE
Remove typhoeus dependency

### DIFF
--- a/g5-logger.gemspec
+++ b/g5-logger.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'pry-nav'
 
-  spec.add_runtime_dependency 'typhoeus'
   spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
We don't use it anymore since 46ed24f995d4ef4f0e085eb04a87d63e87f10a9b.